### PR TITLE
Adjust partition assignment logic based on transport status

### DIFF
--- a/utils/functions.jl
+++ b/utils/functions.jl
@@ -145,7 +145,11 @@ function process_flows_rep_period_partition_file(
         from_partition = df_assets_partition[df_assets_partition.asset.==row.from_asset, :partition]
         to_partition = df_assets_partition[df_assets_partition.asset.==row.to_asset, :partition]
         if !isempty(from_partition) && !isempty(to_partition)
-            row.partition = max(from_partition[1], to_partition[1])
+            if row.is_transport
+                row.partition = max(from_partition[1], to_partition[1])
+            else
+                row.partition = min(from_partition[1], to_partition[1])
+            end
         elseif !isempty(from_partition)
             row.partition = from_partition[1]
         elseif !isempty(to_partition)


### PR DESCRIPTION
This pull request includes a change to the `process_flows_rep_period_partition_file` function in `utils/functions.jl`. The change adds a conditional check to determine the appropriate partition value based on whether the row represents a transport.

* [`utils/functions.jl`](diffhunk://#diff-0cb1d7ec86f939cddfc2d8f3061d150b6ea5aa162a53fc91f2993ca67fbbfa20R148-R152): Added a conditional check to set `row.partition` to the maximum partition if `row.is_transport` is true, otherwise set it to the minimum partition.

Closes #13 